### PR TITLE
Modernise standingstones json

### DIFF
--- a/data/json/mapgen/standing_stones.json
+++ b/data/json/mapgen/standing_stones.json
@@ -3,9 +3,7 @@
     "name": "GROUP_STANDING_STONES",
     "type": "monstergroup",
     "default": "mon_null",
-    "monsters": [
-      { "monster": "mon_darkman", "freq": 100, "cost_multiplier": 1, "conditions" : ["NIGHT"] }
-    ]
+    "monsters": [ { "monster": "mon_darkman", "freq": 100, "cost_multiplier": 1, "conditions": [ "NIGHT" ] } ]
   },
   {
     "type": "mapgen",
@@ -40,16 +38,16 @@
         "ffffff..........ffffffff"
       ],
       "terrain": {
+        "#": "t_dirt",
         ".": [ "t_grass", "t_grass", "t_grass", "t_dirt", "t_dirt" ],
-        "f": [ "t_grass", "t_grass", "t_grass", "t_tree", "t_tree_young", "t_underbrush", "t_underbrush", "t_underbrush", "t_dirt" ],
-        "s": "t_dirt",
-        "o": "t_dirt",
         "O": "t_dirt",
-        "#": "t_dirt"
+        "f": [ "t_grass", "t_grass", "t_grass", "t_tree", "t_tree_young", "t_underbrush", "t_underbrush", "t_underbrush", "t_dirt" ],
+        "o": "t_dirt",
+        "s": "t_dirt"
       },
       "furniture": {
-        "o": "f_boulder_small",
-        "O": "f_boulder_large"
+        "O": "f_boulder_large",
+        "o": "f_boulder_small"
       },
       "traps": {
         "#": "tr_brazier"

--- a/data/json/mapgen/standing_stones.json
+++ b/data/json/mapgen/standing_stones.json
@@ -26,7 +26,7 @@
         "...........ss...O.....ff",
         ".........ossssss.......f",
         ".......sssssssss.....fff",
-        "fff..OssssssOsss.o.....f",
+        "fff..Ossss#sOsss.o.....f",
         "f......sssssssss.....o..",
         "........ossssssO.......f",
         "o.......ss..ss.........f",
@@ -39,21 +39,24 @@
         "ff.f.f.f.f....fff..f.f.f",
         "ffffff..........ffffffff"
       ],
-      "set": [ { "point": "trap", "id": "tr_brazier", "x": 10, "y": 12 } ],
       "terrain": {
         ".": [ "t_grass", "t_grass", "t_grass", "t_dirt", "t_dirt" ],
         "f": [ "t_grass", "t_grass", "t_grass", "t_tree", "t_tree_young", "t_underbrush", "t_underbrush", "t_underbrush", "t_dirt" ],
         "s": "t_dirt",
         "o": "t_dirt",
-        "O": "t_dirt"
+        "O": "t_dirt",
+        "#": "t_dirt"
       },
       "furniture": {
         "o": "f_boulder_small",
         "O": "f_boulder_large"
       },
-      "place_loot": [
-        { "item": "stick", "x": 10, "y": 12, "repeat": 2 }
-      ]
+      "traps": {
+        "#": "tr_brazier"
+      },
+      "loot": {
+        "#": { "item": "stick", "repeat": [ 1, 2 ] }
+      }
     }
   }
 ]


### PR DESCRIPTION
Not sure brazier is placed at coords `[10,12]`. Easily fixed.

`terrain`/`furniture` needs to be in specific order for linter to be happy.

Actual linter rule in PR https://github.com/CleverRaven/Cataclysm-DDA/pull/20064

P.S. Are you mapmaking by hand or some software? If the latter, might be useful to direct its devs here to showcase the mappables (`traps`, `loot`).