### PR TITLE
lint: add rule to format monstergroup:monster:conditions

### DIFF
--- a/tools/format/format.conf
+++ b/tools/format/format.conf
@@ -607,6 +607,7 @@ monstergroup:monsters:@=NOWRAP
 monstergroup:monsters:@:monster
 monstergroup:monsters:@:freq
 monstergroup:monsters:@:cost_multiplier
+monstergroup:monsters:@:conditions=ARRAY,NOWRAP
 monstergroup:monsters:@:pack_size=ARRAY,NOWRAP
 
 # Vehicles


### PR DESCRIPTION
Had my logic fail. The linter fix should go in together with the code that needs it, to allow testing PR https://github.com/CleverRaven/Cataclysm-DDA/pull/20060. Same reason that PR must add an example location+monstergroup while adding a flag.